### PR TITLE
fix(nuspec): iconUrl asset has been removed

### DIFF
--- a/templates/newrelic-dotnet.nuspec
+++ b/templates/newrelic-dotnet.nuspec
@@ -9,7 +9,7 @@
     <licenseUrl>https://www.newrelic.com</licenseUrl>
     <projectUrl>https://www.newrelic.com</projectUrl>
     <packageSourceUrl>https://github.com/TechIsCool/chocolatey-newrelic-dotnet</packageSourceUrl>
-    <iconUrl>http://newrelic.com/assets/newrelic/source/NewRelic-logo-square.png</iconUrl>
+    <iconUrl>https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>New Relic .NET Agent that allows you to monitor your .NET application. Package has following parameters:
 


### PR DESCRIPTION
NewRelic removed the `iconUrl` asset from their website replacing with current asset.